### PR TITLE
Update NovaLinkResource.php

### DIFF
--- a/src/NovaLinkResource.php
+++ b/src/NovaLinkResource.php
@@ -2,10 +2,12 @@
 
 namespace EricLagarda\NovaLinkResource;
 
+use Laravel\Nova\Metable;
 use Laravel\Nova\Tool;
 
 class NovaLinkResource extends Tool
 {
+    use Metable;
     /**
      * Perform any tasks that need to happen when the tool is booted.
      *


### PR DESCRIPTION
The reason for the "withMeta( )" not found error message during upgrade to >3.18, was as a result of a missing "Metable" Trait not being imported into "NovaLinkResource.php".