### PR TITLE
Update NovaLinkResource.php

### DIFF
--- a/src/NovaLinkResource.php
+++ b/src/NovaLinkResource.php
@@ -2,10 +2,12 @@
 
 namespace EricLagarda\NovaLinkResource;
 
+use Laravel\Nova\Metable;
 use Laravel\Nova\Tool;
 
 class NovaLinkResource extends Tool
 {
+   use Metable;
     /**
      * Perform any tasks that need to happen when the tool is booted.
      *


### PR DESCRIPTION
Added missing Trait Import of the "Laravel\Nova\Metable", causing "withMeta( )" method not found error for versions >= 3.18